### PR TITLE
Removed unused import and restored existing checks

### DIFF
--- a/Tests/test_image_point.py
+++ b/Tests/test_image_point.py
@@ -1,5 +1,7 @@
 import pytest
 
+from PIL import Image
+
 from .helper import assert_image_equal, hopper
 
 
@@ -57,3 +59,8 @@ def test_f_mode():
     im = hopper("F")
     with pytest.raises(ValueError):
         im.point(None)
+
+
+def test_coerce_e_deprecation():
+    with pytest.warns(DeprecationWarning):
+        assert Image.coerce_e(2).data == 2

--- a/Tests/test_image_point.py
+++ b/Tests/test_image_point.py
@@ -17,6 +17,7 @@ def test_sanity():
         im.point(list(range(256)))
     im.point(lambda x: x * 1)
     im.point(lambda x: x + 1)
+    im.point(lambda x: x - 1)
     im.point(lambda x: x * 1 + 1)
     im.point(lambda x: 0.1 + 0.2 * x)
     im.point(lambda x: -x)
@@ -24,6 +25,7 @@ def test_sanity():
     im.point(lambda x: 1 - x / 2)
     im.point(lambda x: (2 + x) / 3)
     im.point(lambda x: 0.5)
+    im.point(lambda x: x / 1)
     with pytest.raises(TypeError):
         im.point(lambda x: x * x)
     with pytest.raises(TypeError):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -29,7 +29,6 @@ import builtins
 import io
 import logging
 import math
-import numbers
 import os
 import re
 import struct

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -431,7 +431,9 @@ def _getencoder(mode, encoder_name, args, extra=()):
 
 
 def coerce_e(value):
+    deprecate("coerce_e", 10)
     return value if isinstance(value, _E) else _E(1, value)
+
 
 class _E:
     def __init__(self, scale, data):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -430,19 +430,21 @@ def _getencoder(mode, encoder_name, args, extra=()):
 # Simple expression analyzer
 
 
-# _Affine(m, b) represents the polynomial m x + b
-class _Affine:
-    def __init__(self, m, b):
-        self.m = m
-        self.b = b
+def coerce_e(value):
+    return value if isinstance(value, _E) else _E(1, value)
+
+class _E:
+    def __init__(self, scale, data):
+        self.scale = scale
+        self.data = data
 
     def __neg__(self):
-        return _Affine(-self.m, -self.b)
+        return _E(-self.scale, -self.data)
 
     def __add__(self, other):
-        if isinstance(other, _Affine):
-            return _Affine(self.m + other.m, self.b + other.b)
-        return _Affine(self.m, self.b + other)
+        if isinstance(other, _E):
+            return _E(self.scale + other.scale, self.data + other.data)
+        return _E(self.scale, self.data + other)
 
     __radd__ = __add__
 
@@ -453,21 +455,21 @@ class _Affine:
         return other + -self
 
     def __mul__(self, other):
-        if isinstance(other, _Affine):
+        if isinstance(other, _E):
             return NotImplemented
-        return _Affine(self.m * other, self.b * other)
+        return _E(self.scale * other, self.data * other)
 
     __rmul__ = __mul__
 
     def __truediv__(self, other):
-        if isinstance(other, _Affine):
+        if isinstance(other, _E):
             return NotImplemented
-        return _Affine(self.m / other, self.b / other)
+        return _E(self.scale / other, self.data / other)
 
 
 def _getscaleoffset(expr):
-    a = expr(_Affine(1.0, 0.0))
-    return (a.m, a.b) if isinstance(a, _Affine) else (0.0, a)
+    a = expr(_E(1, 0))
+    return (a.scale, a.data) if isinstance(a, _E) else (0, a)
 
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/6254

1. You can see that Lint is failing because `numbers` is imported but unused - https://github.com/python-pillow/Pillow/runs/6245537875?check_suite_focus=true. I've removed the import here.
2. I've restored the checks for `im.point(lambda x: x - 1)` and `im.point(lambda x: x / 1)`. Unless you have thoughts otherwise, it seems nicer to keep the previous checks in.
3. While this may not matter on a practical level, in theory, `coerce_e` is a public method. So I've added a commit here restoring `coerce_e` and the `data` property. I've also kept the original name of `_E`. Again, it may not matter either way, but I think keeping the same name is better than changing it for now.
4. However, I have added a commit here deprecating `coerce_e`. There's no need for users to have access to it, so in future, `_E` can be changed however we like.